### PR TITLE
Uncaught ReferenceError: gtag is not defined

### DIFF
--- a/modules/cms/console/scaffold/theme/tailwind/assets/src/js/theme.stub
+++ b/modules/cms/console/scaffold/theme/tailwind/assets/src/js/theme.stub
@@ -28,6 +28,6 @@
     });
 }(jQuery));
 
-if (typeof(gtag) !== 'function') {
+if (typeof(gtag) !== 'undefined' && typeof(gtag) !== 'function') {
     gtag = function() { console.log('GoogleAnalytics not present.'); }
 }


### PR DESCRIPTION
If gtag() is undefined an error is raised.